### PR TITLE
Update return value on application success.

### DIFF
--- a/OpenCL1.2/BFS/main.cpp
+++ b/OpenCL1.2/BFS/main.cpp
@@ -483,5 +483,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/BS/main.cpp
+++ b/OpenCL1.2/BS/main.cpp
@@ -322,5 +322,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/CEDD/main.cpp
+++ b/OpenCL1.2/CEDD/main.cpp
@@ -409,5 +409,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/CEDT/main.cpp
+++ b/OpenCL1.2/CEDT/main.cpp
@@ -359,5 +359,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/HSTI/main.cpp
+++ b/OpenCL1.2/HSTI/main.cpp
@@ -316,5 +316,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/HSTO/main.cpp
+++ b/OpenCL1.2/HSTO/main.cpp
@@ -295,5 +295,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/PAD/main.cpp
+++ b/OpenCL1.2/PAD/main.cpp
@@ -315,5 +315,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/RSCD/main.cpp
+++ b/OpenCL1.2/RSCD/main.cpp
@@ -427,5 +427,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/RSCT/main.cpp
+++ b/OpenCL1.2/RSCT/main.cpp
@@ -350,5 +350,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/SC/main.cpp
+++ b/OpenCL1.2/SC/main.cpp
@@ -318,5 +318,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/SSSP/main.cpp
+++ b/OpenCL1.2/SSSP/main.cpp
@@ -505,5 +505,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/TQ/main.cpp
+++ b/OpenCL1.2/TQ/main.cpp
@@ -302,5 +302,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/TQH/main.cpp
+++ b/OpenCL1.2/TQH/main.cpp
@@ -287,5 +287,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL1.2/TRNS/main.cpp
+++ b/OpenCL1.2/TRNS/main.cpp
@@ -316,5 +316,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/BFS/main.cpp
+++ b/OpenCL2.0/BFS/main.cpp
@@ -326,5 +326,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/BS/main.cpp
+++ b/OpenCL2.0/BS/main.cpp
@@ -322,5 +322,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/CEDD/main.cpp
+++ b/OpenCL2.0/CEDD/main.cpp
@@ -409,5 +409,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/CEDT/main.cpp
+++ b/OpenCL2.0/CEDT/main.cpp
@@ -335,5 +335,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/HSTI/main.cpp
+++ b/OpenCL2.0/HSTI/main.cpp
@@ -316,5 +316,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/HSTO/main.cpp
+++ b/OpenCL2.0/HSTO/main.cpp
@@ -295,5 +295,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/PAD/main.cpp
+++ b/OpenCL2.0/PAD/main.cpp
@@ -315,5 +315,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/RSCD/main.cpp
+++ b/OpenCL2.0/RSCD/main.cpp
@@ -427,5 +427,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/RSCT/main.cpp
+++ b/OpenCL2.0/RSCT/main.cpp
@@ -285,5 +285,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/SC/main.cpp
+++ b/OpenCL2.0/SC/main.cpp
@@ -318,5 +318,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/SSSP/main.cpp
+++ b/OpenCL2.0/SSSP/main.cpp
@@ -335,5 +335,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/TQ/main.cpp
+++ b/OpenCL2.0/TQ/main.cpp
@@ -297,5 +297,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/TQH/main.cpp
+++ b/OpenCL2.0/TQH/main.cpp
@@ -282,5 +282,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }

--- a/OpenCL2.0/TRNS/main.cpp
+++ b/OpenCL2.0/TRNS/main.cpp
@@ -316,5 +316,5 @@ int main(int argc, char **argv) {
     timer.print("Deallocation", 1);
 
     printf("Test Passed\n");
-    return 1;
+    return 0;
 }


### PR DESCRIPTION
This PR changes the return values of all of the benchmarks. Right now, if one of the chai programs succeeds, it turns 1. Per generally accepted Unix standards, however, a value of '0' is indicative of success.

See, for instance:
[POSIX Standard for exit](http://pubs.opengroup.org/onlinepubs/000095399/functions/exit.html) -- "A value of zero (or EXIT_SUCCESS, which is required to be zero) for the argument status conventionally indicates successful termination."
[Linux Documentation](http://www.tldp.org/LDP/abs/html/exit-status.html) - "A successful command returns a 0, while an unsuccessful one returns a non-zero value that usually can be interpreted as an error code"

Returning a non-zero value from these benchmarks makes them difficult to run in scripted systems.