### PR TITLE
Update makefiles

### DIFF
--- a/OpenCL1.2/BFS/Makefile
+++ b/OpenCL1.2/BFS/Makefile
@@ -32,25 +32,48 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
     $(error CHAI_OCL_LIB not defined. This environment variable must be defined to point to the location of the OpenCL library)
 endif
-LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
+LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm
+
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
 
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=bfs
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/BS/Makefile
+++ b/OpenCL1.2/BS/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=bs
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/CEDD/Makefile
+++ b/OpenCL1.2/CEDD/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lm -lOpenCL -lopencv_core -lopencv_highgui -lopencv_imgproc 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=cedd
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/CEDT/Makefile
+++ b/OpenCL1.2/CEDT/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lm -lOpenCL -lopencv_core -lopencv_highgui -lopencv_imgproc 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=cedt
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/HSTI/Makefile
+++ b/OpenCL1.2/HSTI/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=hsti
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/HSTO/Makefile
+++ b/OpenCL1.2/HSTO/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=hsto
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/PAD/Makefile
+++ b/OpenCL1.2/PAD/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=pad
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/RSCD/Makefile
+++ b/OpenCL1.2/RSCD/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=rscd
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/RSCT/Makefile
+++ b/OpenCL1.2/RSCT/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=rsct
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/SC/Makefile
+++ b/OpenCL1.2/SC/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=sc
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/SSSP/Makefile
+++ b/OpenCL1.2/SSSP/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=sssp
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/TQ/Makefile
+++ b/OpenCL1.2/TQ/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=tq
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/TQH/Makefile
+++ b/OpenCL1.2/TQH/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=tqh
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL1.2/TRNS/Makefile
+++ b/OpenCL1.2/TRNS/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=trns
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/BFS/Makefile
+++ b/OpenCL2.0/BFS/Makefile
@@ -32,25 +32,48 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
     $(error CHAI_OCL_LIB not defined. This environment variable must be defined to point to the location of the OpenCL library)
 endif
-LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
+LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm
+
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
 
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=bfs
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/BS/Makefile
+++ b/OpenCL2.0/BS/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=bs
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/CEDD/Makefile
+++ b/OpenCL2.0/CEDD/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lm -lOpenCL -lopencv_core -lopencv_highgui -lopencv_imgproc 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=cedd
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/CEDT/Makefile
+++ b/OpenCL2.0/CEDT/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lm -lOpenCL -lopencv_core -lopencv_highgui -lopencv_imgproc 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=cedt
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/HSTI/Makefile
+++ b/OpenCL2.0/HSTI/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=hsti
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/HSTO/Makefile
+++ b/OpenCL2.0/HSTO/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=hsto
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/PAD/Makefile
+++ b/OpenCL2.0/PAD/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=pad
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/RSCD/Makefile
+++ b/OpenCL2.0/RSCD/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=rscd
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/RSCT/Makefile
+++ b/OpenCL2.0/RSCT/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=rsct
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/SC/Makefile
+++ b/OpenCL2.0/SC/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/partitioner.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=sc
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/SSSP/Makefile
+++ b/OpenCL2.0/SSSP/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=sssp
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/TQ/Makefile
+++ b/OpenCL2.0/TQ/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=tq
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/TQH/Makefile
+++ b/OpenCL2.0/TQH/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=tqh
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)

--- a/OpenCL2.0/TRNS/Makefile
+++ b/OpenCL2.0/TRNS/Makefile
@@ -32,7 +32,13 @@
 #  THE SOFTWARE.
 # 
 
-CXX=g++
+ifndef CXX
+    CXX=g++
+else
+    ifeq ($(CXX),c++)
+    CXX=g++
+    endif
+endif
 CXX_FLAGS=-std=c++11
 
 ifndef CHAI_OCL_LIB
@@ -40,17 +46,34 @@ ifndef CHAI_OCL_LIB
 endif
 LIB=-L/usr/lib/ -L$(CHAI_OCL_LIB) -lOpenCL -lm 
 
+is_pthreads=$(shell ${CXX} -v 2> /dev/stdout | grep "Thread model" | awk {'print $$3'})
+ifeq ($(is_pthreads),posix)
+    LIB+=-pthread
+endif
+
 ifndef CHAI_OCL_INC
     $(error CHAI_OCL_INC not defined. This environment variable must be defined to point to the location of the OpenCL header files)
 endif
 INC=-I$(CHAI_OCL_INC)
 
-DEP=kernel.cpp kernel.h main.cpp support/common.h support/ocl.h support/timer.h support/verify.h
 SRC=main.cpp kernel.cpp
+OBJECTS=$(SRC:.cpp=.o)
+DEPS=$(OBJECTS:.o=.d)
 EXE=trns
 
-all:
-	$(CXX) $(CXX_FLAGS) $(SRC) $(LIB) $(INC) -o $(EXE)
+.PHONY: all
+all: $(EXE)
+
+%.o: %.cpp
+	$(CXX) $(CXX_FLAGS) $(INC) -c -MMD -o $@ $<
+
+%.d: ;
+.PRECIOUS: %.d
+
+$(EXE): $(OBJECTS)
+	$(CXX) $(CXX_FLAGS) $(OBJECTS) $(LIB) -o $(EXE)
 
 clean:
-	rm -f $(EXE)
+	rm -f $(EXE) *.o *.d
+
+-include $(DEPS)


### PR DESCRIPTION
The benchmarks in chai take advanced of std::thread by including \<thread\>. However, depending on the compiler, the underlying thread mechanism may be POSIX threads. If so, the benchmark must be linked against pthreads. See, for example, [this StackOverflow thread](http://stackoverflow.com/questions/8649828/what-is-the-correct-link-options-to-use-stdthread-in-gcc-under-linux).

As such, this PR updates the makefiles in the benchmarks to conditionally link against pthread if the compiler reports that its underlying threading model is POSIX.

In addition, these changes remove the need to manually enter DEPS (head files, etc.) from the makefiles. Instead, it uses [auto-dependency generation](http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/) to handle this automatically.

Finally, I removed the hard-coding of the compiler to g++. If the CXX variable isn't set, or if it's the default 'c++', then it uses g++. However, if some other environment variable sets CXX, that is used. This can be useful in the future for running tools like LLVM and the clang static analyzer on the code.