### PR TITLE
Check if clFile.open("kernel.cl", std::ios::in) succeeds for all benchmarks.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,25 @@
-#FROM nvidia/cuda:8.0-devel-ubuntu16.04
 FROM nvidia/cuda:8.0-devel
-
-#RUN nvcc --version
-#RUN ls /usr/local/cuda/include
-#RUN ls /usr/local/cuda/lib64
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Install OpenCV
 RUN apt-get update && apt-get install --no-install-recommends -y libopencv-dev
 
+# Set up NVIDIA OpenCL environment
 RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential \
-#    nvidia-opencl-icd-367 \
-    nvidia-modprobe \
+    #nvidia-modprobe \
     ocl-icd-libopencl1 \
     ocl-icd-opencl-dev \
-    clinfo \
+    #clinfo \
     && rm -rf /var/lib/apt/lists/*
-
 RUN mkdir -p /etc/OpenCL/vendors && \
     echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
-#RUN ls /etc/OpenCL/vendors
-#RUN cat /etc/OpenCL/vendors/nvidia.icd
 
-RUN cat /etc/ld.so.conf.d/nvidia.conf
-
+# Make the OpenCL1.2 files visible to the container
 ADD ./OpenCL1.2 chai/OpenCL1.2
 
-# Build  OpenCL 1.2
+# Build  OpenCL 1.2 version of all benchmarks
 RUN export CHAI_OCL_LIB=/usr/local/cuda/lib64 export CHAI_OCL_INC=/usr/local/cuda/include && \
     cd chai/OpenCL1.2 && \
     for bench in *; do \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+#FROM nvidia/cuda:8.0-devel-ubuntu16.04
+FROM nvidia/cuda:8.0-devel
+
+#RUN nvcc --version
+#RUN ls /usr/local/cuda/include
+#RUN ls /usr/local/cuda/lib64
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install --no-install-recommends -y libopencv-dev
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+#    nvidia-opencl-icd-367 \
+    nvidia-modprobe \
+    ocl-icd-libopencl1 \
+    ocl-icd-opencl-dev \
+    clinfo \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
+#RUN ls /etc/OpenCL/vendors
+#RUN cat /etc/OpenCL/vendors/nvidia.icd
+
+RUN cat /etc/ld.so.conf.d/nvidia.conf
+
+ADD ./OpenCL1.2 chai/OpenCL1.2
+
+# Build  OpenCL 1.2
+RUN export CHAI_OCL_LIB=/usr/local/cuda/lib64 export CHAI_OCL_INC=/usr/local/cuda/include && \
+    cd chai/OpenCL1.2 && \
+    for bench in *; do \
+      echo $bench; \
+      cd $bench; \
+      make -j; \
+      cd ..; \
+    done

--- a/OpenCL1.2/BFS/support/ocl.h
+++ b/OpenCL1.2/BFS/support/ocl.h
@@ -111,6 +111,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/BS/support/ocl.h
+++ b/OpenCL1.2/BS/support/ocl.h
@@ -110,6 +110,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/CEDD/support/ocl.h
+++ b/OpenCL1.2/CEDD/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/CEDT/support/ocl.h
+++ b/OpenCL1.2/CEDT/support/ocl.h
@@ -114,6 +114,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/HSTI/support/ocl.h
+++ b/OpenCL1.2/HSTI/support/ocl.h
@@ -111,6 +111,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/HSTO/support/ocl.h
+++ b/OpenCL1.2/HSTO/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/PAD/support/ocl.h
+++ b/OpenCL1.2/PAD/support/ocl.h
@@ -111,6 +111,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/RSCD/support/ocl.h
+++ b/OpenCL1.2/RSCD/support/ocl.h
@@ -111,6 +111,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/RSCT/support/ocl.h
+++ b/OpenCL1.2/RSCT/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/SC/support/ocl.h
+++ b/OpenCL1.2/SC/support/ocl.h
@@ -111,6 +111,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/SSSP/support/ocl.h
+++ b/OpenCL1.2/SSSP/support/ocl.h
@@ -111,6 +111,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/TQ/support/ocl.h
+++ b/OpenCL1.2/TQ/support/ocl.h
@@ -111,6 +111,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/TQH/support/ocl.h
+++ b/OpenCL1.2/TQH/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/TRNS/support/ocl.h
+++ b/OpenCL1.2/TRNS/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/README.md
+++ b/README.md
@@ -13,5 +13,10 @@ Install `docker` for your system.
 
 Install `nvidia-docker`.
 
+To build the docker image, use
+
     nvidia-docker build . -t chai
+
+To run a benchmark (for example, BS), do
+
     nvidia-docker run -it chai bash -c "cd chai/OpenCL1.2/BS/ && ./bs"

--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ The current version of Chai is 1.0-alpha.
 #
 
 If you think this work is useful, please cite us at https://github.com/chai-benchmarks/chai for now, until we provide another reference.
+
+## Running with Docker
+
+Install `docker` for your system.
+
+Install `nvidia-docker`.
+
+    nvidia-docker build . -t chai
+    nvidia-docker run -it chai bash -c "cd chai/OpenCL1.2/BS/ && ./bs"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The current version of Chai is 1.0-alpha.
 
 If you think this work is useful, please cite us at https://github.com/chai-benchmarks/chai for now, until we provide another reference.
 
-## Running with Docker
+## Running OpenCL 1.2 benchmarks on NVIDIA with Docker
 
 Install `docker` for your system.
 


### PR DESCRIPTION
Check if the OpenCL kernel file is opened successfully. Exit with a message on failure instead of silently continuing and producing an OpenCL error code somewhere down the line.