### PR TITLE
Check if opencl1.2 kernel file opened successfully

### DIFF
--- a/OpenCL1.2/BFS/support/ocl.h
+++ b/OpenCL1.2/BFS/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/BS/support/ocl.h
+++ b/OpenCL1.2/BS/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/CEDD/support/ocl.h
+++ b/OpenCL1.2/CEDD/support/ocl.h
@@ -115,6 +115,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/CEDT/support/ocl.h
+++ b/OpenCL1.2/CEDT/support/ocl.h
@@ -116,6 +116,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/HSTI/support/ocl.h
+++ b/OpenCL1.2/HSTI/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/HSTO/support/ocl.h
+++ b/OpenCL1.2/HSTO/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/PAD/support/ocl.h
+++ b/OpenCL1.2/PAD/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/RSCD/support/ocl.h
+++ b/OpenCL1.2/RSCD/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/RSCT/support/ocl.h
+++ b/OpenCL1.2/RSCT/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/SC/support/ocl.h
+++ b/OpenCL1.2/SC/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/SSSP/support/ocl.h
+++ b/OpenCL1.2/SSSP/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/TQ/support/ocl.h
+++ b/OpenCL1.2/TQ/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/TQH/support/ocl.h
+++ b/OpenCL1.2/TQH/support/ocl.h
@@ -114,6 +114,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL1.2/TRNS/support/ocl.h
+++ b/OpenCL1.2/TRNS/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 


### PR DESCRIPTION
Emits and error message and exits if the kernel file is not opened successfully. This happens when you don't follow the instructions carefully and run the benchmark executable from somewhere that is not the benchmark folder. This prevents seeing an OpenCL compilation error down the line.