### PR TITLE
Upstream fix opencl2.0 kernel open

### DIFF
--- a/OpenCL2.0/BFS/support/ocl.h
+++ b/OpenCL2.0/BFS/support/ocl.h
@@ -109,6 +109,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/BS/support/ocl.h
+++ b/OpenCL2.0/BS/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/BS/support/ocl.h
+++ b/OpenCL2.0/BS/support/ocl.h
@@ -35,6 +35,7 @@
 
 #include <CL/cl.h>
 #include <fstream>
+#include <iostream>
 
 // Allocation error checking
 #define ERR_1(v1)                                                                                                      \

--- a/OpenCL2.0/CEDD/support/ocl.h
+++ b/OpenCL2.0/CEDD/support/ocl.h
@@ -115,6 +115,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/CEDD/support/ocl.h
+++ b/OpenCL2.0/CEDD/support/ocl.h
@@ -35,6 +35,7 @@
 
 #include <CL/cl.h>
 #include <fstream>
+#include <iostream>
 
 // Allocation error checking
 #define ERR_1(v1)                                                                                                      \

--- a/OpenCL2.0/CEDT/support/ocl.h
+++ b/OpenCL2.0/CEDT/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/HSTI/support/ocl.h
+++ b/OpenCL2.0/HSTI/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/HSTI/support/ocl.h
+++ b/OpenCL2.0/HSTI/support/ocl.h
@@ -35,6 +35,7 @@
 
 #include <CL/cl.h>
 #include <fstream>
+#include <iostream>
 
 // Allocation error checking
 #define ERR_1(v1)                                                                                                      \

--- a/OpenCL2.0/HSTO/support/ocl.h
+++ b/OpenCL2.0/HSTO/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/PAD/support/ocl.h
+++ b/OpenCL2.0/PAD/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/RSCD/support/ocl.h
+++ b/OpenCL2.0/RSCD/support/ocl.h
@@ -112,6 +112,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/RSCD/support/ocl.h
+++ b/OpenCL2.0/RSCD/support/ocl.h
@@ -35,6 +35,7 @@
 
 #include <CL/cl.h>
 #include <fstream>
+#include <iostream>
 
 // Allocation error checking
 #define ERR_1(v1)                                                                                                      \

--- a/OpenCL2.0/RSCT/support/ocl.h
+++ b/OpenCL2.0/RSCT/support/ocl.h
@@ -110,6 +110,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/SC/support/ocl.h
+++ b/OpenCL2.0/SC/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/SSSP/support/ocl.h
+++ b/OpenCL2.0/SSSP/support/ocl.h
@@ -110,6 +110,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/TQ/support/ocl.h
+++ b/OpenCL2.0/TQ/support/ocl.h
@@ -109,6 +109,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/TQH/support/ocl.h
+++ b/OpenCL2.0/TQH/support/ocl.h
@@ -110,6 +110,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 

--- a/OpenCL2.0/TRNS/support/ocl.h
+++ b/OpenCL2.0/TRNS/support/ocl.h
@@ -113,6 +113,10 @@ struct OpenCLSetup {
 
         std::filebuf clFile;
         clFile.open("kernel.cl", std::ios::in);
+        if (!clFile.is_open()) {
+            std::cerr << "Unable to open ./kernel.cl. Exiting...\n";
+            exit(EXIT_FAILURE);
+        }
         std::istream in(&clFile);
         std::string  clCode(std::istreambuf_iterator<char>(in), (std::istreambuf_iterator<char>()));
 


### PR DESCRIPTION
Emits and error message and exits if the kernel file is not opened successfully for OpenCL 2.0 benchmarks. This happens when you don't follow the instructions carefully and run the benchmark executable from somewhere that is not the benchmark folder. This prevents seeing an OpenCL compilation error down the line.