### PR TITLE
Fix version on OCL1.2/BFS/support.ocl.h

### DIFF
--- a/OpenCL1.2/BFS/support/ocl.h
+++ b/OpenCL1.2/BFS/support/ocl.h
@@ -125,7 +125,7 @@ struct OpenCLSetup {
         CL_ERR();
 
         char clOptions[50];
-        sprintf(clOptions, "-I. -cl-std=CL2.0");
+        sprintf(clOptions, "-I. -cl-std=CL1.2");
 
         clStatus = clBuildProgram(clProgram, 0, NULL, clOptions, NULL, NULL);
         if(clStatus == CL_BUILD_PROGRAM_FAILURE) {


### PR DESCRIPTION
I had an error when running this on a Intel HD Graphics GPU. It seems to be a minor bug due to the version.